### PR TITLE
Add backward compatibility for laravelcollective/html < 5.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=5.5.9",
         "laravel/framework": "^5.2",
-        "laravelcollective/html": "^5.0"
+        "laravelcollective/html": "^5.4"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
First Attempt:
I forked it and then added patch and tagged it as v1.0.5, composer stayed at v1.04 (with the incorrect requirements). deleted this fork 

Second Attempt: 
Re-created fork and tagged v1.0.5 to v1.0.3( downgrading it), which fixed my issue. Then added patch and tagged it v1.0.6. 

Hope it helps, thanks J